### PR TITLE
Checking that optional parameters are not already set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@ If you need more than one connection to your database, please configure your con
 
 ## Expected values / services
 
-This *service provider* expect the following configuration / services to be available:
+This *service provider* expects the following configuration / services to be available:
 
 | Name            | Compulsory | Description                            |
 |-----------------|------------|----------------------------------------|
-| dbal.host       | *no*       | The database host. Defaults to *localhost*  |
-| dbal.user       | *no*       | The database user. Defaults to *root*  |
-| dbal.password   | *no*       | The database password. Defaults to *empty*  |
-| dbal.port       | *no*       | The database port. Defaults to *3306*  |
-| dbal.dbname     | **yes**    | The database name.  |
-| dbal.charset    | *no*    | The database character set.  |
-| dbal.driverOptions    | *no*    | An array of driver options. Defaults to `[1002 =>"SET NAMES utf8"]`  |
-| dbal.params       | *no*       | An array of parameters directly passed to the `Connection` object. If this parameter is set, all parameters above are ignored.  |
-| Doctrine\DBAL\Driver       | *no*       | The DBAL driver to use to create the connection. Defaults to DBAL's PDO_MySQL Driver service  |
+| `dbal.host`       | *no*       | The database host. Defaults to *localhost*  |
+| `dbal.user`       | *no*       | The database user. Defaults to *root*  |
+| `dbal.password`   | *no*       | The database password. Defaults to *empty*  |
+| `dbal.port`       | *no*       | The database port. Defaults to *3306*  |
+| `dbal.dbname`     | **yes**    | The database name.  |
+| `dbal.charset`    | *no*    | The database character set.  |
+| `dbal.driverOptions`    | *no*    | An array of driver options. Defaults to `[1002 =>"SET NAMES utf8"]`  |
+| `dbal.params`       | *no*       | An array of parameters directly passed to the `Connection` object. If this parameter is set, all parameters above are ignored.  |
+| `Doctrine\DBAL\Driver`       | *no*       | The DBAL driver to use to create the connection. Defaults to DBAL's PDO_MySQL Driver service  |
 
 
 ## Provided services

--- a/src/DbalServiceProvider.php
+++ b/src/DbalServiceProvider.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: Xavier
- * Date: 04/03/2016
- * Time: 16:46
- */
 
 namespace TheCodingMachine;
-
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
@@ -21,75 +14,108 @@ class DbalServiceProvider implements ServiceProvider
     {
         return [
             Connection::class => 'createConnection',
-            'dbal.host'=> 'getHost',
-            'dbal.user'=> 'getUser',
-            'dbal.password'=> 'getPassword',
-            'dbal.port'=> 'getPort',
-            'dbal.dbname'=> 'getDbname',
-            'dbal.charset'=> 'getCharset',
-            'dbal.driverOptions'=> 'getDriverOptions',
-            Driver::class => 'getDriver'
+            'dbal.host' => 'getHost',
+            'dbal.user' => 'getUser',
+            'dbal.password' => 'getPassword',
+            'dbal.port' => 'getPort',
+            'dbal.dbname' => 'getDbname',
+            'dbal.charset' => 'getCharset',
+            'dbal.driverOptions' => 'getDriverOptions',
+            Driver::class => 'getDriver',
         ];
     }
+
     public static function createConnection(ContainerInterface $container, callable $previous = null) : Connection
     {
-        if($container->has(Connection::class.'.params')) {
+        if ($container->has('dbal.params')) {
             $params = $container->get('dbal.params');
         } else {
             $params = array(
                 'host' => $container->get('dbal.host'),
-                'user' =>$container->get('dbal.user'),
+                'user' => $container->get('dbal.user'),
                 'password' => $container->get('dbal.password'),
                 'port' => $container->get('dbal.port'),
                 'dbname' => $container->get('dbal.dbname'),
                 'charset' => $container->get('dbal.charset'),
-                'driverOptions' => $container->get('dbal.driverOptions')
+                'driverOptions' => $container->get('dbal.driverOptions'),
             );
         }
 
         $driver = $container->get(Driver::class);
 
-        $connection =  new Connection($params, $driver);
+        $connection = new Connection($params, $driver);
 
         return $connection;
     }
 
-    public static function getHost() :string
+    public static function getHost(ContainerInterface $container, callable $previous = null) :string
     {
+        if ($previous !== null) {
+            return $previous();
+        }
+
         return 'localhost';
     }
 
-    public static function getUser():string
+    public static function getUser(ContainerInterface $container, callable $previous = null):string
     {
+        if ($previous !== null) {
+            return $previous();
+        }
+
         return 'root';
     }
 
-    public static function getPassword():string
+    public static function getPassword(ContainerInterface $container, callable $previous = null):string
     {
+        if ($previous !== null) {
+            return $previous();
+        }
+
         return '';
     }
 
-    public static function getPort():int
+    public static function getPort(ContainerInterface $container, callable $previous = null):int
     {
+        if ($previous !== null) {
+            return $previous();
+        }
+
         return 3306;
     }
 
-    public static function getDbname():string
+    public static function getDbname(ContainerInterface $container, callable $previous = null):string
     {
+        if ($previous !== null) {
+            return $previous();
+        }
         throw new DBALException('The "dbname" must be set in the container entry "dbal.dbname"');
     }
 
-    public static function getCharset():string
+    public static function getCharset(ContainerInterface $container, callable $previous = null):string
     {
+        if ($previous !== null) {
+            return $previous();
+        }
+
         return 'utf8';
     }
 
-    public static function getDriverOptions():array
+    public static function getDriverOptions(ContainerInterface $container, callable $previous = null):array
     {
-        return array(1002 =>"SET NAMES utf8");
+        if ($previous !== null) {
+            return $previous();
+        }
+
+        return array(1002 => 'SET NAMES utf8');
     }
-    public static function getDriver():Driver
+
+    public static function getDriver(ContainerInterface $container, callable $previous = null):Driver
     {
+        if ($previous !== null) {
+            return $previous();
+        }
+
         return new Driver\PDOMySql\Driver();
     }
 }


### PR DESCRIPTION
This way, if a param like dbal.dbhost is already defined, it is not overwritten by the default value.

Also, applying some PSR-2 formatting and improving documentation formatting.
